### PR TITLE
VGA driver update

### DIFF
--- a/ethcore/kernel/idtc.c
+++ b/ethcore/kernel/idtc.c
@@ -2,6 +2,7 @@
 #include "kernel/util.h"
 #include "kernel/vga.h"
 #include "klib/kint.h"
+#include "klib/kio.h"
 #include "klib/kmemory.h"
 
 struct idt_entry_struct idt_entries[256];
@@ -139,9 +140,9 @@ isr_handler (struct InterruptRegisters *regs)
 {
   if (regs->int_no < 32)
   {
-    print (exception_messages[regs->int_no]);
-    print ("\n");
-    print ("Exception! System Halted\n");
+    __kputs (exception_messages[regs->int_no]);
+    __kputs ("\n");
+    __kputs ("Exception! System Halted\n");
     for (;;)
       ;
   }

--- a/ethcore/kernel/kernel.c
+++ b/ethcore/kernel/kernel.c
@@ -2,23 +2,9 @@
 #include "kernel/idt.h"
 #include "kernel/keyboard.h"
 #include "kernel/timer.h"
-#include "kernel/util.h"
 #include "kernel/vga.h"
 #include "klib/kint.h"
 #include "klib/kio.h"
-
-void set_screen_color (uint8_t color);
-
-void
-set_screen_color (uint8_t color)
-{
-  uint8_t *video_memory = (uint8_t *)0xB8000;
-
-  for (int i = 0; i < width * height * 2; i += 2)
-  {
-    video_memory[i + 1] = color; // Set the background color byte
-  }
-}
 
 void
 main (void)
@@ -27,11 +13,15 @@ main (void)
   initIdt ();
   initTimer ();
   initKeyboard ();
-  print ("######################\n");
-  print ("#        ETHOS       #\n");
-  print ("######################\n");
-  print ("ethos-->");
-  set_screen_color (0x1F);
+  vga_init ();
+  __kputs ("######################\n");
+  __kputs ("#        ETHOS       #\n");
+  __kputs ("######################\n");
+  vga_set_color (VGA_COLOR_BLUE, VGA_COLOR_WHITE);
+
+  __kputs ("ethos-->");
+  vga_enable_cursor ();
+  vga_clear_screen ();
   for (;;)
     ;
 }

--- a/ethcore/kernel/keyboard.c
+++ b/ethcore/kernel/keyboard.c
@@ -109,7 +109,8 @@ rm ()
   {
     i++;
   }
-  text[--i] = text[i];
+  text[i - 1] = text[i];
+  i--;
 }
 
 void
@@ -129,7 +130,7 @@ delp (char p, char *t)
   if (p == 0)
   {
     append (t);
-    print (t);
+    __kputs (t);
   }
 }
 
@@ -146,7 +147,7 @@ parser (uint8_t code)
   {
     buff[p] = text[p];
   }
-  print (buff);
+  __kputs (buff);
 }
 
 void
@@ -161,8 +162,8 @@ keyboardHandler (struct InterruptRegisters *regs)
   case 29:
   case 16:
     delp (press, "q");
-    print ("\n");
-    print (text);
+    __kputc ('\n');
+    __kputs (text);
     break;
   case 17:
     delp (press, "w");
@@ -284,9 +285,9 @@ keyboardHandler (struct InterruptRegisters *regs)
       if (lowercase[scanCode] == '\n')
       {
         // print("\nethos-->");
-        print ("\n");
-        print (text);
-        print ("\nethos-->");
+        __kputc ('\n');
+        __kputs (text);
+        __kputs ("\nethos-->");
         // parser(57);
         clear ();
       }
@@ -294,11 +295,11 @@ keyboardHandler (struct InterruptRegisters *regs)
       {
         if (capsOn || capsLock)
         {
-          __kprintf ("%c", uppercase[scanCode]);
+          __kputc (uppercase[scanCode]);
         }
         else
         {
-          __kprintf ("%c", lowercase[scanCode]);
+          __kputc (lowercase[scanCode]);
         }
       }
     }

--- a/ethcore/kernel/vga.c
+++ b/ethcore/kernel/vga.c
@@ -1,107 +1,192 @@
 #include "kernel/vga.h"
-#include "klib/kint.h"
+#include "kernel/util.h"
+#include "klib/kmemory.h"
 
-uint16_t column = 0;
-uint16_t line = 0;
-uint16_t *const vga = (uint16_t *const)0xB8000;
-const uint16_t defaultColor = (COLOR8_WHITE << 8) | (COLOR8_BLUE << 12);
-uint16_t currentColor = defaultColor;
+#define __K_DEFAULT_VGA_WIDTH 80
+#define __K_DEFAULT_VGA_HEIGHT 25
+
+#define __K_VGA_BASE 0x0B8000
+
+#define __K_VGA_DEFAULT_COLOR (VGA_COLOR_BLUE << 12) | (VGA_COLOR_WHITE << 8)
+
+struct VgaState
+{
+  uint16_t color;
+  uint32_t width, height;
+
+  uint32_t line, column;
+
+  uint16_t *base;
+};
+
+static struct VgaState vga_state = { 0 };
 
 void
-Reset ()
+__vga_new_line (void)
 {
-  line = 0;
-  column = 0;
-  currentColor = defaultColor;
-
-  for (uint16_t y = 0; y < height; y++)
-  {
-    for (uint16_t x = 0; x < width; x++)
-    {
-      vga[y * width + x] = ' ' | defaultColor;
-    }
-  }
-}
-
-void
-newLine ()
-{
-  if (line < height - 1)
-  {
-    line++;
-    column = 0;
-  }
+  if (vga_state.line < vga_state.height - 1)
+    vga_state.line++;
   else
+    vga_scroll (1);
+
+  vga_state.column = 0;
+  vga_move_cursor (vga_state.column, vga_state.line);
+}
+
+uint16_t
+vga_color (enum VgaColor bg_color, enum VgaColor fg_color)
+{
+  return (bg_color << 12) | (fg_color << 8);
+}
+
+void
+vga_init (void)
+{
+  vga_state.base = (uint16_t *)__K_VGA_BASE;
+  vga_reset ();
+}
+
+void
+vga_set_color (enum VgaColor bg_color, enum VgaColor fg_color)
+{
+  vga_state.color = vga_color (bg_color, fg_color);
+}
+
+void
+vga_clear_screen (void)
+{
+  for (uint8_t *vga_mem = (uint8_t *)vga_state.base;
+       vga_mem < (uint8_t *)(vga_state.base
+                             + (vga_state.width * vga_state.height * 2));
+       vga_mem += 2)
+    *(vga_mem + 1) = (uint8_t)(vga_state.color >> 8);
+}
+
+void
+vga_print (char c)
+{
+  switch (c)
   {
-    scrollUp ();
-    column = 0;
+  case '\n':
+  {
+    __vga_new_line ();
+  }
+  break;
+
+  case '\r':
+  {
+    vga_state.column = 0;
+    vga_move_cursor (vga_state.column, vga_state.line);
+  }
+  break;
+
+  case '\b':
+  {
+    if (vga_state.column == 8)
+    {
+      vga_state.base[vga_state.line * vga_state.width + (++vga_state.column)]
+          = ' ' | vga_state.color;
+      vga_move_cursor (vga_state.column, vga_state.line);
+      break;
+    }
+    if (vga_state.column == 0 && vga_state.line != 0)
+    {
+      vga_state.line--;
+      vga_state.column = vga_state.width;
+    }
+    vga_state.base[vga_state.line * vga_state.width + (--vga_state.column)]
+        = ' ' | vga_state.color;
+    vga_move_cursor (vga_state.column, vga_state.line);
+  }
+  break;
+
+  case '\t':
+  {
+    if (vga_state.column == vga_state.width)
+      __vga_new_line ();
+    uint8_t tab_len = 8 - (vga_state.column % 8);
+    for (; tab_len > 0; tab_len--)
+    {
+      vga_state.base[vga_state.line * vga_state.width + vga_state.column]
+          = ' ' | vga_state.color;
+      vga_state.column++;
+    }
+    vga_move_cursor (vga_state.column, vga_state.line);
+  }
+  break;
+
+  default:
+  {
+    if (vga_state.column == vga_state.width)
+      __vga_new_line ();
+
+    vga_state.base[vga_state.line * vga_state.width + vga_state.column]
+        = c | vga_state.color;
+    vga_state.column++;
+    vga_move_cursor (vga_state.column, vga_state.line);
+  }
+  break;
   }
 }
 
 void
-scrollUp ()
+vga_scroll (uint32_t lines)
 {
-  for (uint16_t y = 0; y < height; y++)
+  for (uint32_t l = 0; l < lines; l++)
   {
-    for (uint16_t x = 0; x < width; x++)
-    {
-      vga[(y - 1) * width + x] = vga[y * width + x];
-    }
-  }
+    for (uint16_t y = 0; y < vga_state.height; y++)
+      for (uint16_t x = 0; x < vga_state.width; x++)
+        vga_state.base[(y - 1) * vga_state.width + x]
+            = vga_state.base[y * vga_state.width + x];
 
-  for (uint16_t x = 0; x < width; x++)
-  {
-    vga[(height - 1) * width + x] = ' ' | currentColor;
+    for (uint16_t x = 0; x < vga_state.width; x++)
+      vga_state.base[(vga_state.height - 1) * vga_state.width + x]
+          = ' ' | vga_state.color;
   }
 }
 
 void
-print (const char *s)
+vga_reset (void)
 {
-  while (*s)
-  {
-    switch (*s)
-    {
-    case '\n':
-      newLine ();
-      break;
-    case '\r':
-      column = 0;
-      break;
-    case '\b':
-      if (column == 8)
-      {
-        vga[line * width + (++column)] = ' ' | currentColor;
-        break;
-      }
-      if (column == 0 && line != 0)
-      {
-        line--;
-        column = width;
-      }
-      vga[line * width + (--column)] = ' ' | currentColor;
-      break;
-    case '\t':
-      if (column == width)
-      {
-        newLine ();
-      }
-      uint16_t tabLen = 4 - (column % 4);
-      while (tabLen != 0)
-      {
-        vga[line * width + (column++)] = ' ' | currentColor;
-        tabLen--;
-      }
-      break;
-    default:
-      if (column == width)
-      {
-        newLine ();
-      }
+  vga_state.base = (uint16_t *)__K_VGA_BASE;
 
-      vga[line * width + (column++)] = *s | currentColor;
-      break;
-    }
-    s++;
-  }
+  vga_state.column = 0;
+  vga_state.line = 0;
+
+  vga_state.width = __K_DEFAULT_VGA_WIDTH;
+  vga_state.height = __K_DEFAULT_VGA_HEIGHT;
+
+  vga_set_color (VGA_COLOR_BLACK, VGA_COLOR_WHITE);
+  vga_clear_screen ();
+
+  vga_disable_cursor ();
+}
+
+void
+vga_enable_cursor (void)
+{
+  outPortB (0x3D4, 0x0A);
+  outPortB (0x3D5, (inPortB (0x3D5) & 0xC0));
+
+  outPortB (0x3D4, 0x0B);
+  outPortB (0x3D5, (inPortB (0x3D5) & 0xE0) | (vga_state.width << 8)
+                       | vga_state.height);
+}
+
+void
+vga_disable_cursor (void)
+{
+  outPortB (0x3D4, 0x0A);
+  outPortB (0x3D5, 0x20);
+}
+
+void
+vga_move_cursor (uint8_t x, uint8_t y)
+{
+  uint16_t pos = y * vga_state.width + x;
+
+  outPortB (0x3D4, 0x0F);
+  outPortB (0x3D5, (uint8_t)(pos & 0xFF));
+  outPortB (0x3D4, 0x0E);
+  outPortB (0x3D5, (uint8_t)((pos >> 8) & 0xFF));
 }

--- a/ethcore/kernel/vga.h
+++ b/ethcore/kernel/vga.h
@@ -1,29 +1,37 @@
 #ifndef __K_VGA_H__
 #define __K_VGA_H__
 
-#define COLOR8_BLACK 0
-#define COLOR8_BLUE 1
-#define COLOR8_GREEN 2
-#define COLOR8_CYAN 3
-#define COLOR8_RED 4
-#define COLOR8_MAGENTA 5
-#define COLOR8_BROWN 6
-#define COLOR8_LIGHT_GREY 7
-#define COLOR8_DARK_GREY 8
-#define COLOR8_LIGHT_BLUE 9
-#define COLOR8_LIGHT_GREEN 10
-#define COLOR8_LIGHT_CYAN 11
-#define COLOR8_LIGHT_RED 12
-#define COLOR8_LIGHT_MAGENTA 13
-#define COLOR8_LIGHT_BROWN 14
-#define COLOR8_WHITE 15
+#include "klib/kint.h"
 
-#define width 80
-#define height 25
+enum VgaColor
+{
+  VGA_COLOR_BLACK = 0x00,
+  VGA_COLOR_BLUE = 0x01,
+  VGA_COLOR_GREEN = 0x02,
+  VGA_COLOR_CYAN = 0x03,
+  VGA_COLOR_RED = 0x04,
+  VGA_COLOR_MAGENTA = 0x05,
+  VGA_COLOR_BROWN = 0x06,
+  VGA_COLOR_LGREY = 0x07,
+  VGA_COLOR_DGREY = 0x08,
+  VGA_COLOR_LBLUE = 0x09,
+  VGA_COLOR_LGREEN = 0x0A,
+  VGA_COLOR_LCYAN = 0x0B,
+  VGA_COLOR_LRED = 0x0C,
+  VGA_COLOR_LMAGENTA = 0x0D,
+  VGA_COLOR_LBROWN = 0x0E,
+  VGA_COLOR_WHITE = 0x0F,
+};
 
-void print (const char *s);
-void scrollUp ();
-void newLine ();
-void Reset ();
+uint16_t vga_color (enum VgaColor bg_color, enum VgaColor fg_color);
+void vga_init (void);
+void vga_set_color (enum VgaColor bg_color, enum VgaColor fg_color);
+void vga_clear_screen (void);
+void vga_print (char c);
+void vga_scroll (uint32_t lines);
+void vga_reset (void);
+void vga_enable_cursor (void);
+void vga_disable_cursor (void);
+void vga_move_cursor (uint8_t x, uint8_t y);
 
 #endif // __K_VGA_H__

--- a/ethcore/klib/kio.c
+++ b/ethcore/klib/kio.c
@@ -22,14 +22,14 @@ int *__kprintf_number (int *, int, char, int);
 void
 __kputc (char c)
 {
-  print (&c);
+  vga_print (c);
 }
 
 void
 __kputs (const char *s)
 {
   for (; *s; s++)
-    __kputc (*s);
+    vga_print (*s);
 }
 
 void


### PR DESCRIPTION
Added Functions:
* `vga_enable_cursor()` - Enable blinking cursor
* `vga_disable_cursor()` - Disable blinking cursor
* `vga_move_cursor()` - Move cursor
* `vga_set_color()` - Set color for VGA driver
* `vga_clear_screen()` - Clear screen with selected color
* `vga_reset()` - Resets VGA driver to its default state

Improvements:
* Now when you print something through `vga_print()` it automatically
adjusts cursor position.
* `vga_print()` now doesn't accept strings, so you need to use
`__kputs()` from `klib`.